### PR TITLE
wp8/winrt should return 0

### DIFF
--- a/flatbuffers/util.h
+++ b/flatbuffers/util.h
@@ -172,7 +172,7 @@ inline std::string AbsolutePath(const std::string &filepath) {
   #ifdef _WIN32
     char abs_path[MAX_PATH]; 
     #if defined(WP8) || defined(WINRT)
-    return ""
+    return 0
 	#else
 		return GetFullPathNameA(filepath.c_str(), MAX_PATH, abs_path, nullptr)
 	#endif


### PR DESCRIPTION
Small fix for AbsolutePath(). WP8/WinRT version should return 0 not "" to be consistent with return value of GetFullPathNameA which is not supported in WP8/WinRT versions.
