### PR TITLE
Match BUILD_SHARED_LIBS for add_library targets

### DIFF
--- a/flatbuffers/CMakeLists.txt
+++ b/flatbuffers/CMakeLists.txt
@@ -14,7 +14,13 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_library(flatbuffers STATIC
+if(BUILD_SHARED_LIBS)
+    set (SHARED_OR_STATIC SHARED)
+else()
+    set (SHARED_OR_STATIC STATIC)
+endif()
+
+add_library(flatbuffers ${SHARED_OR_STATIC}
   ${FLATBUFFERS_SRC}
 )
 

--- a/unzip/CMakeLists.txt
+++ b/unzip/CMakeLists.txt
@@ -4,7 +4,13 @@ set(UNZIP_SRC
   ioapi_mem.cpp
 )
 
-add_library(unzip STATIC
+if(BUILD_SHARED_LIBS)
+    set (SHARED_OR_STATIC SHARED)
+else()
+    set (SHARED_OR_STATIC STATIC)
+endif()
+
+add_library(unzip ${SHARED_OR_STATIC}
   ${UNZIP_SRC}
 )
 

--- a/xxhash/CMakeLists.txt
+++ b/xxhash/CMakeLists.txt
@@ -2,7 +2,13 @@ set(XXHASH
   xxhash.c
 )
 
-add_library(xxhash STATIC
+if(BUILD_SHARED_LIBS)
+    set (SHARED_OR_STATIC SHARED)
+else()
+    set (SHARED_OR_STATIC STATIC)
+endif()
+
+add_library(xxhash ${SHARED_OR_STATIC}
   ${XXHASH}
 )
 


### PR DESCRIPTION
Fixes linker error when linking `libcocos2d.so` with `option(BUILD_SHARED_LIBS ON)`
