### PR TITLE
Add ability to get class name form a tolua c++ class.

### DIFF
--- a/lua/tolua/tolua_map.c
+++ b/lua/tolua/tolua_map.c
@@ -661,6 +661,10 @@ TOLUA_API void tolua_cclass (lua_State* L, const char* lname, const char* name, 
     lua_newtable(L);                    // stack: module lname table
     luaL_getmetatable(L,name);          // stack: module lname table mt
     lua_setmetatable(L, -2);            // stack: module lname table
+    // class_table[".name"] = name
+    lua_pushliteral(L, ".name");        // stack: module lname table ".name"
+    lua_pushstring(L, name);            // stack: module lname table ".name" name
+    lua_rawset(L, -3);                  // stack: module lname table
     //Use a key named ".isclass" to be a flag of class_table
     lua_pushliteral(L, ".isclass");
     lua_pushboolean(L, 1);

--- a/lua/tolua/tolua_map.c
+++ b/lua/tolua/tolua_map.c
@@ -39,6 +39,12 @@ static int tolua_newmetatable (lua_State* L, const char* name)
 
     if (r)
         tolua_classevents(L); /* set meta events */
+    
+    // metatable[".classname"] = name
+    lua_pushliteral(L, ".classname");   // stack: metatable ".classname"
+    lua_pushstring(L, name);            // stack: metatable ".classname" name
+    lua_rawset(L, -3);                  // stack: metatable
+    
     lua_pop(L,1);
     return r;
 }
@@ -661,10 +667,6 @@ TOLUA_API void tolua_cclass (lua_State* L, const char* lname, const char* name, 
     lua_newtable(L);                    // stack: module lname table
     luaL_getmetatable(L,name);          // stack: module lname table mt
     lua_setmetatable(L, -2);            // stack: module lname table
-    // class_table[".name"] = name
-    lua_pushliteral(L, ".name");        // stack: module lname table ".name"
-    lua_pushstring(L, name);            // stack: module lname table ".name" name
-    lua_rawset(L, -3);                  // stack: module lname table
     //Use a key named ".isclass" to be a flag of class_table
     lua_pushliteral(L, ".isclass");
     lua_pushboolean(L, 1);


### PR DESCRIPTION
Add class_table[".name"] = classname.
This enables ability to get class name form a tolua c++ class.

eg `print(cc.Node['.name'])` -- will prints "cc.Node".

This should solve cocos2d/cocos2d-x#14101.
