### PR TITLE
修改适用于Win10工程的LUA

### DIFF
--- a/lua/lua/loadlib.c
+++ b/lua/lua/loadlib.c
@@ -94,7 +94,7 @@ static lua_CFunction ll_sym (lua_State *L, void *lib, const char *sym) {
 
 #undef setprogdir
 
-static void setprogdir (lua_State *L) {
+static void setprogdir(lua_State *L){
   char buff[MAX_PATH + 1];
   char *lb;
   DWORD nsize = sizeof(buff)/sizeof(char);
@@ -125,7 +125,11 @@ static void ll_unloadlib (void *lib) {
 
 
 static void *ll_load (lua_State *L, const char *path) {
+#if (WINAPI_FAMILY > 0 && WINAPI_FAMILY_APP > 0) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+	HMODULE lib = LoadPackagedLibrary(path, 0);
+#else // WINAPI_FAMILY == WINAPI_FAMILY_APP
   HINSTANCE lib = LoadLibraryA(path);
+#endif
   if (lib == NULL) pusherror(L);
   return lib;
 }

--- a/lua/lua/lobject.c
+++ b/lua/lua/lobject.c
@@ -203,7 +203,11 @@ void luaO_chunkid (char *out, const char *source, size_t bufflen) {
       if (len > bufflen) len = bufflen;
       strcpy(out, "[string \"");
       if (source[len] != '\0') {  /* must truncate? */
+#if (WINAPI_FAMILY > 0 && WINAPI_FAMILY_APP > 0) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+		strcat_s(out, len, source);
+#else
         strncat(out, source, len);
+#endif
         strcat(out, "...");
       }
       else

--- a/lua/lua/luaconf.h
+++ b/lua/lua/luaconf.h
@@ -207,7 +207,7 @@
 @* of a function in debug information.
 ** CHANGE it if you want a different size.
 */
-#define LUA_IDSIZE	60
+#define LUA_IDSIZE	512
 
 
 /*

--- a/lua/tolua/tolua_map.c
+++ b/lua/tolua/tolua_map.c
@@ -493,7 +493,11 @@ TOLUA_API int tolua_register_gc (lua_State* L, int lo)
 TOLUA_API void tolua_usertype (lua_State* L, const char* type)
 {
     char ctype[128] = "const ";
-    strncat(ctype,type,120);
+#if (WINAPI_FAMILY > 0 && WINAPI_FAMILY_APP > 0) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+	strcat_s(ctype, 120, type);
+#else
+	strncat(ctype, type, 120);
+#endif
 
     /* create both metatables */
     if (tolua_newmetatable(L,ctype) && tolua_newmetatable(L,type))
@@ -637,8 +641,13 @@ TOLUA_API void tolua_cclass (lua_State* L, const char* lname, const char* name, 
 {
     char cname[128] = "const ";
     char cbase[128] = "const ";
-    strncat(cname,name,120);
-    strncat(cbase,base,120);
+#if (WINAPI_FAMILY > 0 && WINAPI_FAMILY_APP > 0) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+	strcat_s(cname, 120, name);
+	strcat_s(cbase, 120, base);
+#else
+	strncat(cname, name, 120);
+	strncat(cbase, base, 120);
+#endif
 
     mapinheritance(L,name,base);
     mapinheritance(L,cname,name);
@@ -690,8 +699,13 @@ TOLUA_API void tolua_addbase(lua_State* L, char* name, char* base) {
 
     char cname[128] = "const ";
     char cbase[128] = "const ";
-    strncat(cname,name,120);
-    strncat(cbase,base,120);
+#if (WINAPI_FAMILY > 0 && WINAPI_FAMILY_APP > 0) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+	strcat_s(cname, 120, name);
+	strcat_s(cbase, 120, base);
+#else
+	strncat(cname, name, 120);
+	strncat(cbase, base, 120);
+#endif
 
     mapsuper(L,cname,cbase);
     mapsuper(L,name,base);


### PR DESCRIPTION
1.strncat在Win10ARM下不能正确运作，替换为strcat_s
2.LoadLibraryA在Win10提换为LoadPackagedLibrary
3.因路径可能过长（测试中遇到该问题），所以修改宏LUA_IDSIZE为512
