### PR TITLE
Remove include of  CCPlatformDefine.h.

### DIFF
--- a/unzip/unzip.h
+++ b/unzip/unzip.h
@@ -43,8 +43,6 @@
 #ifndef _unz64_H
 #define _unz64_H
 
-#include "CCPlatformDefine.h"
-
 #ifndef _ZLIB_H
 #include "zlib.h"
 #endif


### PR DESCRIPTION
`#include "CCPlatformDefine.h"` breaks cocos2d-x build when [remove unnecessary search path](https://github.com/cocos2d/cocos2d-x/pull/15286).
(we have remove use of lots of search path for cocos2d-x headers see https://github.com/cocos2d/cocos2d-x/pull/15281)
