### PR TITLE
rapidxml: change parse terminatation check for a non-null-terminated buffer

### DIFF
--- a/rapidxml/rapidxml.hpp
+++ b/rapidxml/rapidxml.hpp
@@ -1376,17 +1376,21 @@ namespace rapidxml
     template<class Ch = char>
     class xml_document : public xml_node<Ch>, public memory_pool<Ch>
     {
-
+        enum class parse_result
+        {
+            ok,
+            expected_close_tag,
+        };
+        parse_result parse_result_ = parse_result::ok;
     public:
 
         //! Constructs empty XML document
         xml_document()
             : xml_node<Ch>(node_document)
         {
-            endptr_ = nullptr;
         }
 
-        Ch *endptr_;
+
         //! Parses zero-terminated XML string according to given flags.
         //! Passed string will be modified by the parser, unless rapidxml::parse_non_destructive flag is used.
         //! The string must persist for the lifetime of the document.
@@ -1399,7 +1403,7 @@ namespace rapidxml
         //! Each new call to parse removes previous nodes and attributes (if any), but does not clear memory pool.
         //! \param text XML data to parse; pointer is non-const to denote fact that this data may be modified by the parser.
         template<int Flags>
-        void parse(Ch *text, int nLen)
+        void parse(Ch *text, int length)
         {
             assert(text);
 
@@ -1407,22 +1411,18 @@ namespace rapidxml
             this->remove_all_nodes();
             this->remove_all_attributes();
 
-            endptr_ = nullptr;
-            if (nLen > 0)
-            {
-                endptr_ = text + nLen;
-            }
-
             // Parse BOM, if any
             parse_bom<Flags>(text);
 
+            auto endch = text[length - 1];
+            text[length - 1] = 0;
+
             // Parse children
-            while (1)
-            {
-                // Skip whitespace before node
-                skip<whitespace_pred, Flags>(text, endptr_);
-                if (*text == 0 || text >= endptr_)
-                    break;
+        _L_Loop:
+            {	// Skip whitespace before node
+                skip<whitespace_pred, Flags>(text);
+                if (*text == 0)
+                    goto _L_end;
 
                 // Parse and append new child
                 if (*text == Ch('<'))
@@ -1433,8 +1433,20 @@ namespace rapidxml
                 }
                 else
                     RAPIDXML_PARSE_ERROR("expected <", text);
+                goto _L_Loop;
             }
-
+        _L_end:;
+            // check parse result.
+            if (parse_result_ == parse_result::ok) {
+                if (endch == '<') {
+                    RAPIDXML_PARSE_ERROR("unrecognized tag", text);
+                }
+            }
+            else { // parse_result_ == parse_result::expected_close_tag
+                if (endch != '>') {
+                    RAPIDXML_PARSE_ERROR("expected >", text);
+                }
+            }
         }
 
         //! Clears the document by deleting all nodes and clearing the memory pool.
@@ -1582,10 +1594,10 @@ namespace rapidxml
 
         // Skip characters until predicate evaluates to true
         template<class StopPred, int Flags>
-        static void skip(Ch *&text, Ch *textEnd = NULL)
+        static void skip(Ch *&text)
         {
             Ch *tmp = text;
-            while ((textEnd == NULL || tmp < textEnd) && StopPred::test(*tmp))
+            while (StopPred::test(*tmp))
                 ++tmp;
             text = tmp;
         }
@@ -1792,7 +1804,7 @@ namespace rapidxml
             xml_node<Ch> *declaration = this->allocate_node(node_declaration);
 
             // Skip whitespace before attributes or ?>
-            skip<whitespace_pred, Flags>(text, endptr_);
+            skip<whitespace_pred, Flags>(text);
 
             // Parse declaration attributes
             parse_node_attributes<Flags>(text, declaration);
@@ -1925,13 +1937,13 @@ namespace rapidxml
 
                 // Extract PI target name
                 Ch *name = text;
-                skip<node_name_pred, Flags>(text, endptr_);
+                skip<node_name_pred, Flags>(text);
                 if (text == name)
                     RAPIDXML_PARSE_ERROR("expected PI target", text);
                 pi->name(name, text - name);
 
                 // Skip whitespace between pi target and pi
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Remember start of pi
                 Ch *value = text;
@@ -2079,13 +2091,13 @@ namespace rapidxml
 
             // Extract element name
             Ch *name = text;
-            skip<node_name_pred, Flags>(text, endptr_);
+            skip<node_name_pred, Flags>(text);
             if (text == name)
                 RAPIDXML_PARSE_ERROR("expected element name", text);
             element->name(name, text - name);
 
             // Skip whitespace between element name and attributes or >
-            skip<whitespace_pred, Flags>(text, endptr_);
+            skip<whitespace_pred, Flags>(text);
 
             // Parse attributes, if any
             parse_node_attributes<Flags>(text, element);
@@ -2099,12 +2111,18 @@ namespace rapidxml
             else if (*text == Ch('/'))
             {
                 ++text;
-                if (*text != Ch('>'))
-                    RAPIDXML_PARSE_ERROR("expected >", text);
-                ++text;
+                if (*text != Ch('>')) {
+                    parse_result_ = parse_result::expected_close_tag;
+                    if (*text != 0)
+                        RAPIDXML_PARSE_ERROR("expected >", text);
+                }
+                else ++text;
             }
-            else
-                RAPIDXML_PARSE_ERROR("expected >", text);
+            else {
+                parse_result_ = parse_result::expected_close_tag;
+                if (*text != 0)
+                    RAPIDXML_PARSE_ERROR("expected >", text);
+            }
 
             // Place zero terminator after name
             if (!(Flags & parse_no_string_terminators))
@@ -2211,7 +2229,7 @@ namespace rapidxml
             {
                 // Skip whitespace between > and node contents
                 Ch *contents_start = text;      // Store start of node contents before whitespace is skipped
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
                 Ch next_char = *text;
 
                 // After data nodes, instead of continuing the loop, control jumps here.
@@ -2234,20 +2252,23 @@ namespace rapidxml
                         {
                             // Skip and validate closing tag name
                             Ch *closing_name = text;
-                            skip<node_name_pred, Flags>(text, endptr_);
+                            skip<node_name_pred, Flags>(text);
                             if (!internal::compare(node->name(), node->name_size(), closing_name, text - closing_name, true))
                                 RAPIDXML_PARSE_ERROR("invalid closing tag name", text);
                         }
                         else
                         {
                             // No validation, just skip name
-                            skip<node_name_pred, Flags>(text, endptr_);
+                            skip<node_name_pred, Flags>(text);
                         }
                         // Skip remaining whitespace after node name
-                        skip<whitespace_pred, Flags>(text, endptr_);
-                        if (*text != Ch('>'))
-                            RAPIDXML_PARSE_ERROR("expected >", text);
-                        ++text;     // Skip '>'
+                        skip<whitespace_pred, Flags>(text);
+                        if (*text != Ch('>')) {
+                            parse_result_ = parse_result::expected_close_tag;
+                            if (*text != 0)
+                                RAPIDXML_PARSE_ERROR("expected >", text);
+                        }
+                        else ++text;     // Skip '>'
                         return;     // Node closed, finished parsing contents
                     }
                     else
@@ -2282,7 +2303,7 @@ namespace rapidxml
                 // Extract attribute name
                 Ch *name = text;
                 ++text;     // Skip first character of attribute name
-                skip<attribute_name_pred, Flags>(text, endptr_);
+                skip<attribute_name_pred, Flags>(text);
                 if (text == name)
                     RAPIDXML_PARSE_ERROR("expected attribute name", name);
 
@@ -2292,7 +2313,7 @@ namespace rapidxml
                 node->append_attribute(attribute);
 
                 // Skip whitespace after attribute name
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Skip =
                 if (*text != Ch('='))
@@ -2304,7 +2325,7 @@ namespace rapidxml
                     attribute->name()[attribute->name_size()] = 0;
 
                 // Skip whitespace after =
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Skip quote and remember if it was ' or "
                 Ch quote = *text;
@@ -2333,7 +2354,7 @@ namespace rapidxml
                     attribute->value()[attribute->value_size()] = 0;
 
                 // Skip whitespace after attribute value
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
             }
         }
 

--- a/rapidxml/rapidxml.hpp
+++ b/rapidxml/rapidxml.hpp
@@ -1435,7 +1435,7 @@ namespace rapidxml
                     RAPIDXML_PARSE_ERROR("expected <", text);
                 goto _L_Loop;
             }
-        _L_end:;
+        _L_end:
             // check parse result.
             if (parse_result_ == parse_result::ok) {
                 if (endch == '<') {

--- a/rapidxml/rapidxml_iterators.hpp
+++ b/rapidxml/rapidxml_iterators.hpp
@@ -15,14 +15,14 @@ namespace rapidxml
     template<class Ch>
     class node_iterator
     {
-    
+
     public:
         typedef xml_node<Ch> value_type;
         typedef value_type &reference;
         typedef value_type *pointer;
         typedef std::ptrdiff_t difference_type;
         typedef std::bidirectional_iterator_tag iterator_category;
-        
+
         node_iterator()
             : m_node(0)
         {
@@ -32,7 +32,7 @@ namespace rapidxml
             : m_node(node->first_node())
         {
         }
-        
+
         reference operator *() const
         {
             assert(m_node);
@@ -93,7 +93,7 @@ namespace rapidxml
     template<class Ch>
     class attribute_iterator
     {
-    
+
     public:
 
         typedef xml_attribute<Ch> value_type;
@@ -101,7 +101,7 @@ namespace rapidxml
         typedef value_type *pointer;
         typedef std::ptrdiff_t difference_type;
         typedef std::bidirectional_iterator_tag iterator_category;
-        
+
         attribute_iterator()
             : m_attribute(0)
         {
@@ -111,7 +111,7 @@ namespace rapidxml
             : m_attribute(node->first_attribute())
         {
         }
-        
+
         reference operator *() const
         {
             assert(m_attribute);

--- a/rapidxml/rapidxml_print.hpp
+++ b/rapidxml/rapidxml_print.hpp
@@ -13,8 +13,8 @@
 
 // Only include streams if not disabled
 #ifndef RAPIDXML_NO_STREAMS
-    #include <ostream>
-    #include <iterator>
+#include <ostream>
+#include <iterator>
 #endif
 
 namespace rapidxml
@@ -31,15 +31,15 @@ namespace rapidxml
     //! \cond internal
     namespace internal
     {
-        
+
         ///////////////////////////////////////////////////////////////////////////
         // Internal character operations
-        
+
         /// template fwd
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-    
+
         // Copy characters from given range to given output iterator
         template<class OutIt, class Ch>
         inline OutIt copy_chars(const Ch *begin, const Ch *end, OutIt out)
@@ -48,7 +48,7 @@ namespace rapidxml
                 *out++ = *begin++;
             return out;
         }
-        
+
         // Copy characters from given range to given output iterator and expand
         // characters into references (&lt; &gt; &apos; &quot; &amp;)
         template<class OutIt, class Ch>
@@ -67,17 +67,17 @@ namespace rapidxml
                     case Ch('<'):
                         *out++ = Ch('&'); *out++ = Ch('l'); *out++ = Ch('t'); *out++ = Ch(';');
                         break;
-                    case Ch('>'): 
+                    case Ch('>'):
                         *out++ = Ch('&'); *out++ = Ch('g'); *out++ = Ch('t'); *out++ = Ch(';');
                         break;
-                    case Ch('\''): 
+                    case Ch('\''):
                         *out++ = Ch('&'); *out++ = Ch('a'); *out++ = Ch('p'); *out++ = Ch('o'); *out++ = Ch('s'); *out++ = Ch(';');
                         break;
-                    case Ch('"'): 
+                    case Ch('"'):
                         *out++ = Ch('&'); *out++ = Ch('q'); *out++ = Ch('u'); *out++ = Ch('o'); *out++ = Ch('t'); *out++ = Ch(';');
                         break;
-                    case Ch('&'): 
-                        *out++ = Ch('&'); *out++ = Ch('a'); *out++ = Ch('m'); *out++ = Ch('p'); *out++ = Ch(';'); 
+                    case Ch('&'):
+                        *out++ = Ch('&'); *out++ = Ch('a'); *out++ = Ch('m'); *out++ = Ch('p'); *out++ = Ch(';');
                         break;
                     default:
                         *out++ = *begin;    // No expansion, copy character
@@ -109,7 +109,7 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
-    
+
         // Print children of the node                               
         template<class OutIt, class Ch>
         inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent)
@@ -195,7 +195,7 @@ namespace rapidxml
             *out = Ch('<'), ++out;
             out = copy_chars(node->name(), node->name() + node->name_size(), out);
             out = print_attributes(out, node, flags);
-            
+
             // If node is childless
             if (node->value_size() == 0 && !node->first_node())
             {
@@ -254,11 +254,11 @@ namespace rapidxml
 
             // Print attributes
             out = print_attributes(out, node, flags);
-            
+
             // Print declaration end
             *out = Ch('?'), ++out;
             *out = Ch('>'), ++out;
-            
+
             return out;
         }
 
@@ -318,7 +318,7 @@ namespace rapidxml
             *out = Ch('>'), ++out;
             return out;
         }
-        
+
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)
@@ -326,57 +326,57 @@ namespace rapidxml
             // Print proper node type
             switch (node->type())
             {
-                    
-                    // Document
-                case node_document:
-                    out = print_children<OutIt, Ch>(out, node, flags, indent);
-                    break;
-                    
-                    // Element
-                case node_element:
-                    out = print_element_node(out, node, flags, indent);
-                    break;
-                    
-                    // Data
-                case node_data:
-                    out = print_data_node(out, node, flags, indent);
-                    break;
-                    
-                    // CDATA
-                case node_cdata:
-                    out = print_cdata_node(out, node, flags, indent);
-                    break;
-                    
-                    // Declaration
-                case node_declaration:
-                    out = print_declaration_node(out, node, flags, indent);
-                    break;
-                    
-                    // Comment
-                case node_comment:
-                    out = print_comment_node(out, node, flags, indent);
-                    break;
-                    
-                    // Doctype
-                case node_doctype:
-                    out = print_doctype_node(out, node, flags, indent);
-                    break;
-                    
-                    // Pi
-                case node_pi:
-                    out = print_pi_node(out, node, flags, indent);
-                    break;
-                    
-                    // Unknown
-                default:
-                    assert(0);
-                    break;
+
+                // Document
+            case node_document:
+                out = print_children<OutIt, Ch>(out, node, flags, indent);
+                break;
+
+                // Element
+            case node_element:
+                out = print_element_node(out, node, flags, indent);
+                break;
+
+                // Data
+            case node_data:
+                out = print_data_node(out, node, flags, indent);
+                break;
+
+                // CDATA
+            case node_cdata:
+                out = print_cdata_node(out, node, flags, indent);
+                break;
+
+                // Declaration
+            case node_declaration:
+                out = print_declaration_node(out, node, flags, indent);
+                break;
+
+                // Comment
+            case node_comment:
+                out = print_comment_node(out, node, flags, indent);
+                break;
+
+                // Doctype
+            case node_doctype:
+                out = print_doctype_node(out, node, flags, indent);
+                break;
+
+                // Pi
+            case node_pi:
+                out = print_pi_node(out, node, flags, indent);
+                break;
+
+                // Unknown
+            default:
+                assert(0);
+                break;
             }
-            
+
             // If indenting not disabled, add line break after node
             if (!(flags & print_no_indenting))
-            *out = Ch('\n'), ++out;
-            
+                *out = Ch('\n'), ++out;
+
             // Return modified iterator
             return out;
         }
@@ -392,7 +392,7 @@ namespace rapidxml
     //! \param node Node to be printed. Pass xml_document to print entire document.
     //! \param flags Flags controlling how XML is printed.
     //! \return Output iterator pointing to position immediately after last character of printed text.
-    template<class OutIt, class Ch> 
+    template<class OutIt, class Ch>
     inline OutIt print(OutIt out, const xml_node<Ch> &node, int flags = 0)
     {
         return internal::print_node(out, &node, flags, 0);
@@ -405,7 +405,7 @@ namespace rapidxml
     //! \param node Node to be printed. Pass xml_document to print entire document.
     //! \param flags Flags controlling how XML is printed.
     //! \return Output stream.
-    template<class Ch> 
+    template<class Ch>
     inline std::basic_ostream<Ch> &print(std::basic_ostream<Ch> &out, const xml_node<Ch> &node, int flags = 0)
     {
         print(std::ostream_iterator<Ch>(out), node, flags);
@@ -416,7 +416,7 @@ namespace rapidxml
     //! \param out Output stream to print to.
     //! \param node Node to be printed.
     //! \return Output stream.
-    template<class Ch> 
+    template<class Ch>
     inline std::basic_ostream<Ch> &operator <<(std::basic_ostream<Ch> &out, const xml_node<Ch> &node)
     {
         return print(out, node);

--- a/rapidxml/rapidxml_sax3.hpp
+++ b/rapidxml/rapidxml_sax3.hpp
@@ -109,6 +109,7 @@ namespace rapidxml
         {
             xmlSAX2Text(s, len);
         }
+
     private:
         tok_string elementName;
         std::vector<const char*> elementAttrs;
@@ -125,6 +126,13 @@ namespace rapidxml
     class xml_sax3_parser
     {
         xml_sax3_handler* handler_;
+
+        enum class parse_result
+        {
+            ok,
+            expected_close_tag,
+        };
+        parse_result parse_result_ = parse_result::ok;
     public:
 
         //! Constructs empty XML document
@@ -133,7 +141,6 @@ namespace rapidxml
             handler_ = handler;
         }
 
-        Ch *endptr_;
         //! Parses zero-terminated XML string according to given flags.
         //! Passed string will be modified by the parser, unless rapidxml::parse_non_destructive flag is used.
         //! The string must persist for the lifetime of the document.
@@ -146,30 +153,27 @@ namespace rapidxml
         //! Each new call to parse removes previous nodes and attributes (if any), but does not clear memory pool.
         //! \param text XML data to parse; pointer is non-const to denote fact that this data may be modified by the parser.
         template<int Flags = parse_normal>
-        void parse(Ch *text, int nLen)
+        void parse(Ch *text, int length)
         {
             assert(text);
 
             // Remove current contents
             //this->remove_all_nodes();
             //this->remove_all_attributes();
-
-            endptr_ = nullptr;
-            if (nLen > 0)
-            {
-                endptr_ = text + nLen;
-            }
+            // save last character and make buffer zero-terminated (speeds up parsing)
+            auto endch = text[length - 1];
+            text[length - 1] = 0;
 
             // Parse BOM, if any
             parse_bom<Flags>(text);
 
             // Parse children
-            while (1)
+        _L_Loop:
             {
                 // Skip whitespace before node
-                skip<whitespace_pred, Flags>(text, endptr_);
-                if (*text == 0 || text >= endptr_)
-                    break;
+                skip<whitespace_pred, Flags>(text);
+                if (*text == 0)
+                    goto _L_end;
 
                 // Parse and append new child
                 if (*text == Ch('<'))
@@ -179,8 +183,22 @@ namespace rapidxml
                 }
                 else
                     RAPIDXML_PARSE_ERROR("expected <", text);
+
+                goto _L_Loop;
             }
 
+        _L_end:
+            // check parse result.
+            if (parse_result_ == parse_result::ok) {
+                if (endch == '<') {
+                    RAPIDXML_PARSE_ERROR("unrecognized tag", text);
+                }
+            }
+            else { // parse_result_ == parse_result::expected_close_tag
+                if (endch != '>') {
+                    RAPIDXML_PARSE_ERROR("expected >", text);
+                }
+            }
         }
 
         //! Clears the document by deleting all nodes and clearing the memory pool.
@@ -328,10 +346,10 @@ namespace rapidxml
 
         // Skip characters until predicate evaluates to true
         template<class StopPred, int Flags>
-        static void skip(Ch *&text, Ch *textEnd = NULL)
+        static void skip(Ch *&text)
         {
             Ch *tmp = text;
-            while ((textEnd == NULL || tmp < textEnd) && StopPred::test(*tmp))
+            while (StopPred::test(*tmp))
                 ++tmp;
             text = tmp;
         }
@@ -537,7 +555,7 @@ namespace rapidxml
             // xml_node<Ch> *declaration = this->allocate_node(node_declaration);
 
             // Skip whitespace before attributes or ?>
-            skip<whitespace_pred, Flags>(text, endptr_);
+            skip<whitespace_pred, Flags>(text);
 
             // Parse declaration attributes
             parse_node_attributes<Flags>(text/*, declaration*/);
@@ -672,13 +690,13 @@ namespace rapidxml
 
                 // Extract PI target name
                 Ch *name = text;
-                skip<node_name_pred, Flags>(text, endptr_);
+                skip<node_name_pred, Flags>(text);
                 if (text == name)
                     RAPIDXML_PARSE_ERROR("expected PI target", text);
                 // pi->name(name, text - name); // TODO: DNT notify for pi
 
                 // Skip whitespace between pi target and pi
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Remember start of pi
                 Ch *value = text;
@@ -837,7 +855,7 @@ namespace rapidxml
 
             // Extract element name
             tok_string elementName(text, 0);
-            skip<node_name_pred, Flags>(text, endptr_);
+            skip<node_name_pred, Flags>(text);
             elementName.second = text - elementName.first;
             if (0 == elementName.second)
                 RAPIDXML_PARSE_ERROR("expected element name", text);
@@ -845,7 +863,7 @@ namespace rapidxml
             handler_->xmlSAX3StartElement(elementName.first, elementName.second);
 
             // Skip whitespace between element name and attributes or >
-            skip<whitespace_pred, Flags>(text, endptr_);
+            skip<whitespace_pred, Flags>(text);
 
             // Parse attributes, if any
             parse_node_attributes<Flags>(text);
@@ -861,12 +879,18 @@ namespace rapidxml
             else if (*text == Ch('/'))
             {
                 ++text;
-                if (*text != Ch('>'))
-                    RAPIDXML_PARSE_ERROR("expected >", text);
-                ++text;
+                if (*text != Ch('>')) {
+                    parse_result_ = parse_result::expected_close_tag;
+                    if (*text != 0)
+                        RAPIDXML_PARSE_ERROR("expected >", text);
+                }
+                else ++text;
             }
-            else
-                RAPIDXML_PARSE_ERROR("expected >", text);
+            else {
+                parse_result_ = parse_result::expected_close_tag;
+                if (*text != 0)
+                    RAPIDXML_PARSE_ERROR("expected >", text);
+            }
 
             // Place zero terminator after name
             if (!(Flags & parse_no_string_terminators)) {
@@ -975,7 +999,7 @@ namespace rapidxml
             {
                 // Skip whitespace between > and node contents
                 Ch *contents_start = text;      // Store start of node contents before whitespace is skipped
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
                 Ch next_char = *text;
 
                 // After data nodes, instead of continuing the loop, control jumps here.
@@ -998,20 +1022,23 @@ namespace rapidxml
                         {
                             // Skip and validate closing tag name
                             Ch *closing_name = text;
-                            skip<node_name_pred, Flags>(text, endptr_);
+                            skip<node_name_pred, Flags>(text);
                             if (!internal::compare(elementName.first, elementName.second, closing_name, text - closing_name, true))
                                 RAPIDXML_PARSE_ERROR("invalid closing tag name", text);
                         }
                         else
                         {
                             // No validation, just skip name
-                            skip<node_name_pred, Flags>(text, endptr_);
+                            skip<node_name_pred, Flags>(text);
                         }
                         // Skip remaining whitespace after node name
-                        skip<whitespace_pred, Flags>(text, endptr_);
-                        if (*text != Ch('>'))
-                            RAPIDXML_PARSE_ERROR("expected >", text);
-                        ++text;     // Skip '>'
+                        skip<whitespace_pred, Flags>(text);
+                        if (*text != Ch('>')) {
+                            parse_result_ = parse_result::expected_close_tag;
+                            if (*text != 0)
+                                RAPIDXML_PARSE_ERROR("expected >", text);
+                        }
+                        else ++text;     // Skip '>'
                         return;     // Node closed, finished parsing contents
                     }
                     else
@@ -1047,7 +1074,7 @@ namespace rapidxml
                 // Extract attribute name
                 Ch *name = text;
                 ++text;     // Skip first character of attribute name
-                skip<attribute_name_pred, Flags>(text, endptr_);
+                skip<attribute_name_pred, Flags>(text);
                 if (text == name)
                     RAPIDXML_PARSE_ERROR("expected attribute name", name);
 
@@ -1058,7 +1085,7 @@ namespace rapidxml
                 // node->append_attribute(attribute);
 
                 // Skip whitespace after attribute name
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Skip =
                 if (*text != Ch('='))
@@ -1070,7 +1097,7 @@ namespace rapidxml
                     name[namesize] = 0;
 
                 // Skip whitespace after =
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
 
                 // Skip quote and remember if it was ' or "
                 Ch quote = *text;
@@ -1102,7 +1129,7 @@ namespace rapidxml
                 handler_->xmlSAX3Attr(name, namesize, value, valuesize);
 
                 // Skip whitespace after attribute value
-                skip<whitespace_pred, Flags>(text, endptr_);
+                skip<whitespace_pred, Flags>(text);
             }
         }
 

--- a/rapidxml/rapidxml_sax3.hpp
+++ b/rapidxml/rapidxml_sax3.hpp
@@ -131,7 +131,6 @@ namespace rapidxml
         xml_sax3_parser(xml_sax3_handler* handler)
         {
             handler_ = handler;
-            endptr_ = nullptr;
         }
 
         Ch *endptr_;

--- a/rapidxml/rapidxml_utils.hpp
+++ b/rapidxml/rapidxml_utils.hpp
@@ -20,9 +20,9 @@ namespace rapidxml
     template<class Ch = char>
     class file
     {
-        
+
     public:
-        
+
         //! Loads file into the memory. Data will be automatically destroyed by the destructor.
         //! \param filename Filename to load.
         file(const char *filename)
@@ -34,12 +34,12 @@ namespace rapidxml
             if (!stream)
                 throw runtime_error(std::string("cannot open file ") + filename);
             stream.unsetf(ios::skipws);
-            
+
             // Determine stream size
             stream.seekg(0, ios::end);
             size_t size = stream.tellg();
-            stream.seekg(0);   
-            
+            stream.seekg(0);
+
             // Load data and add terminating 0
             m_data.resize(size + 1);
             stream.read(&m_data.front(), static_cast<streamsize>(size));
@@ -59,7 +59,7 @@ namespace rapidxml
                 throw runtime_error("error reading stream");
             m_data.push_back(0);
         }
-        
+
         //! Gets file data.
         //! \return Pointer to data of file.
         Ch *data()


### PR DESCRIPTION
The idea is from pugixml.
