### PR TITLE
Recreate libfmod.so.6 symlinks

### DIFF
--- a/linux-specific/fmod/prebuilt/64-bit/libfmod.so.6
+++ b/linux-specific/fmod/prebuilt/64-bit/libfmod.so.6
@@ -1,0 +1,1 @@
+libfmod.so

--- a/linux-specific/fmod/prebuilt/64-bit/libfmodL.so.6
+++ b/linux-specific/fmod/prebuilt/64-bit/libfmodL.so.6
@@ -1,0 +1,1 @@
+libfmodL.so


### PR DESCRIPTION
Those symlinks were removed in 7c9d86e1972298d3580989fccc3ec19b1acc9d0c
but they are actually need.

Doing readelf -d libfmod.so, shows:

    0x000000000000000e (SONAME)             Library soname: [libfmod.so.6]

and this magic SONAME ELF field must be getting used by ld, man ld says:

    -soname=name
        When an executable is linked with a shared object which has a DT_SONAME field,
        then when the executable is run the dynamic linker will attempt to load the shared
        object specified by the DT_SONAME field rather than the using the file name given to the linker.

libfmod is a closed source blob, the symlink looks like the only solution.

Fixes:

- https://github.com/cocos2d/cocos2d-x/issues/15137
- https://github.com/cocos2d/cocos2d-x/issues/16511
- https://github.com/cocos2d/cocos2d-x/issues/17917

Tested in Ubuntu 17.04.