### PR TITLE
modern cmake, set needed target macro define

### DIFF
--- a/lua/luasocket/CMakeLists.txt
+++ b/lua/luasocket/CMakeLists.txt
@@ -38,6 +38,10 @@ add_library(${target_name} STATIC
   ${${target_name}_src}
 )
 
+if(LINUX)
+  target_compile_definitions(${target_name} PRIVATE _GNU_SOURCE)
+endif()
+
 target_include_directories(${target_name} 
   INTERFACE ..
   PRIVATE ../lua

--- a/websockets/CMakeLists.txt
+++ b/websockets/CMakeLists.txt
@@ -9,13 +9,13 @@ include(../cmake/CocosExternalConfig.cmake)
 
 add_library(${target_name} STATIC IMPORTED GLOBAL)
 
-# include libs depended
-# add_subdirectory(../openssl ${CMAKE_BINARY_DIR}/websockets/openssl)
-# add_subdirectory(../uv ${CMAKE_BINARY_DIR}/websockets/uv)
-
 set_target_properties(${target_name} PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include/${platform_name}"
 )
+set_target_properties(${target_name} PROPERTIES
+  INTERFACE_COMPILE_DEFINITIONS "LWS_WITH_LIBUV"
+)
+
 set_property(TARGET ${target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "ext_ssl")
 set_property(TARGET ${target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "ext_crypto")
 set_property(TARGET ${target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES "ext_uv")


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/pull/19139

modern cmake style use target_* to set macro define and compile options into `cocos2d` target, so that external libs can't access to those values.