### PR TITLE
fix tinyxml wrong dependence

### DIFF
--- a/tinyxml2/CMakeLists.txt
+++ b/tinyxml2/CMakeLists.txt
@@ -21,5 +21,3 @@ set_target_properties(${target_name}
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     FOLDER "External"
 )
-
-# TOCHECK, "tinyxml2.h" depend on cocos platform headers ""platform/CCPlatformMacros.h"", why?

--- a/tinyxml2/tinyxml2.h
+++ b/tinyxml2/tinyxml2.h
@@ -24,9 +24,21 @@ distribution.
 #ifndef TINYXML2_INCLUDED
 #define TINYXML2_INCLUDED
 
-// #include "platform/CCPlatformConfig.h"
-// #include "platform/CCPlatformMacros.h"
-#define CC_DLL 
+// external "tinyxml2.h" shouldn't depend on cocos internal headers "CCPlatformMacros.h"
+#if defined(_MSC_VER)
+#   if defined(CC_STATIC)
+#       define CC_DLL
+#   else
+#       if defined(_USRDLL)
+#           define CC_DLL   __declspec(dllexport)
+#       else         /* use a DLL library */
+#           define CC_DLL   __declspec(dllimport)
+#       endif  
+#   endif
+#else
+#   define CC_DLL
+#endif
+
 
 #if defined(ANDROID_NDK) || defined(__BORLANDC__) || (CC_TARGET_PLATFORM == CC_PLATFORM_BLACKBERRY)
 #   include <ctype.h>


### PR DESCRIPTION
headers in external libs shouldn't depend on cocos internal headers