### PR TITLE
fix warnings found by clang-tidy

### DIFF
--- a/flatbuffers/util.h
+++ b/flatbuffers/util.h
@@ -121,12 +121,12 @@ static const char kPathSeparator = '\\';
 static const char *PathSeparatorSet = "\\/";  // Intentionally no ':'
 #else
 static const char kPathSeparator = kPosixPathSeparator;
-static const char *PathSeparatorSet = "/";
+static const char PathSeparatorSet = '/';
 #endif // _WIN32
 
 // Returns the path with the extension, if any, removed.
 inline std::string StripExtension(const std::string &filepath) {
-  size_t i = filepath.find_last_of(".");
+  size_t i = filepath.find_last_of('.');
   return i != std::string::npos ? filepath.substr(0, i) : filepath;
 }
 


### PR DESCRIPTION
* performance-faster-string-find

I hope we have some kind of test for this repo