### PR TITLE
Allow overriding the default external libraries with game-side versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(BUILD_EXT_POLY2TRI "Build with internal poly2tri support" ON)
 option(BUILD_EXT_MD5 "Build with internal md5 support" ON)
 option(BUILD_EXT_ZLIB "Build with internal zlib support" ON)
 option(BUILD_EXT_CURL "Build with internal curl support" ON)
+option(BUILD_EXT_UNZIP "Build with internal unzip support" ON)
 
 add_library(external empty.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,108 @@
 cmake_minimum_required(VERSION 3.6)
 project(external)
 
+option(BUILD_EXT_BOX2D "Build with internal Box2D support" ON)
+option(BUILD_EXT_CHIPMUNK "Build with internal chipmunk support" ON)
+option(BUILD_EXT_FREETYPE2 "Build with internal freetype2 support" ON)
+option(BUILD_EXT_RECAST "Build with internal recast support" ON)
+option(BUILD_EXT_BULLET "Build with internal bullet support" ON)
+option(BUILD_EXT_JPEG "Build with internal jpeg support" ON)
+option(BUILD_EXT_OPENSSL "Build with internal openssl support" ON)
+option(BUILD_EXT_TIFF "Build with internal tiff support" ON)
+option(BUILD_EXT_UV "Build with internal uv support" ON)
+option(BUILD_EXT_WEBP "Build with internal webp support" ON)
+option(BUILD_EXT_WEBSOCKETS "Build with internal websockets support" ON)
+option(BUILD_EXT_TINYXML2 "Build with internal tinyxml2 support" ON)
+option(BUILD_EXT_XXHASH "Build with internal xxhash support" ON)
+option(BUILD_EXT_XXTEA "Build with internal xxtea support" ON)
+option(BUILD_EXT_CLIPPER "Build with internal clipper support" ON)
+option(BUILD_EXT_EDTAA3FUNC "Build with internal edtaa3func support" ON)
+option(BUILD_EXT_CONVERTUTF "Build with internal ConvertUTF support" ON)
+option(BUILD_EXT_POLY2TRI "Build with internal poly2tri support" ON)
+option(BUILD_EXT_MD5 "Build with internal md5 support" ON)
+option(BUILD_EXT_ZLIB "Build with internal zlib support" ON)
+option(BUILD_EXT_CURL "Build with internal curl support" ON)
+
 add_library(external empty.cpp)
 
-add_subdirectory(Box2D)
-add_subdirectory(chipmunk)
-add_subdirectory(freetype2)
-add_subdirectory(recast)
-add_subdirectory(bullet)
-add_subdirectory(jpeg)
-add_subdirectory(openssl)
-add_subdirectory(tiff)
-add_subdirectory(uv)
-add_subdirectory(webp)
-add_subdirectory(websockets)
-add_subdirectory(tinyxml2)
-add_subdirectory(xxhash)
-add_subdirectory(xxtea)
-add_subdirectory(clipper)
-add_subdirectory(edtaa3func)
-add_subdirectory(ConvertUTF)
-add_subdirectory(poly2tri)
-add_subdirectory(md5)
+if(BUILD_EXT_BOX2D)
+    add_subdirectory(Box2D)
+    target_link_libraries(external ext_box2d)
+endif(BUILD_EXT_BOX2D)
+if(BUILD_EXT_CHIPMUNK)
+    add_subdirectory(chipmunk)
+    target_link_libraries(external ext_chipmunk)
+endif(BUILD_EXT_CHIPMUNK)
+if(BUILD_EXT_FREETYPE2)
+    add_subdirectory(freetype2)
+    target_link_libraries(external ext_freetype)
+endif(BUILD_EXT_FREETYPE2)
+if(BUILD_EXT_RECAST)
+    add_subdirectory(recast)
+    target_link_libraries(external ext_recast)
+endif(BUILD_EXT_RECAST)
+if(BUILD_EXT_BULLET)
+    add_subdirectory(bullet)
+    target_link_libraries(external ext_bullet)
+endif(BUILD_EXT_BULLET)
+if(BUILD_EXT_JPEG)
+    add_subdirectory(jpeg)
+    target_link_libraries(external ext_jpeg)
+endif(BUILD_EXT_JPEG)
+if(BUILD_EXT_OPENSSL)
+    add_subdirectory(openssl)
+    target_link_libraries(external ext_ssl)
+    target_link_libraries(external ext_crypto)
+endif(BUILD_EXT_OPENSSL)
+if(BUILD_EXT_TIFF)
+    add_subdirectory(tiff)
+    target_link_libraries(external ext_tiff)
+endif(BUILD_EXT_TIFF)
+if(BUILD_EXT_UV)
+    add_subdirectory(uv)
+    target_link_libraries(external ext_uv)
+endif(BUILD_EXT_UV)
+if(BUILD_EXT_WEBP)
+    add_subdirectory(webp)
+    target_link_libraries(external ext_webp)
+endif(BUILD_EXT_WEBP)
+if(BUILD_EXT_WEBSOCKETS)
+    add_subdirectory(websockets)
+    target_link_libraries(external ext_websockets)
+endif(BUILD_EXT_WEBSOCKETS)
+if(BUILD_EXT_TINYXML2)
+    add_subdirectory(tinyxml2)
+    target_link_libraries(external ext_tinyxml2)
+endif(BUILD_EXT_TINYXML2)
+if(BUILD_EXT_XXHASH)
+    add_subdirectory(xxhash)
+    target_link_libraries(external ext_xxhash)
+endif(BUILD_EXT_XXHASH)
+if(BUILD_EXT_XXTEA)
+    add_subdirectory(xxtea)
+    target_link_libraries(external ext_xxtea)
+endif(BUILD_EXT_XXTEA)
+if(BUILD_EXT_CLIPPER)
+    add_subdirectory(clipper)
+    target_link_libraries(external ext_clipper)
+endif(BUILD_EXT_CLIPPER)
+if(BUILD_EXT_EDTAA3FUNC)
+    add_subdirectory(edtaa3func)
+    target_link_libraries(external ext_edtaa3func)
+endif(BUILD_EXT_EDTAA3FUNC)
+if(BUILD_EXT_CONVERTUTF)
+    add_subdirectory(ConvertUTF)
+    target_link_libraries(external ext_convertUTF)
+endif(BUILD_EXT_CONVERTUTF)
+if(BUILD_EXT_POLY2TRI)
+    add_subdirectory(poly2tri)
+    target_link_libraries(external ext_poly2tri)
+endif(BUILD_EXT_POLY2TRI)
 
-target_link_libraries(external
-    ext_box2d
-    ext_chipmunk
-    ext_freetype
-    ext_recast
-    ext_jpeg
-    ext_uv
-    ext_webp
-    ext_bullet
-    ext_ssl
-    ext_crypto
-    ext_tiff
-    ext_websockets
-    ext_tinyxml2
-    ext_xxhash
-    ext_xxtea
-    ext_clipper
-    ext_edtaa3func
-    ext_convertUTF
-    ext_poly2tri
-    ext_md5
-)
-
+if(BUILD_EXT_MD5)
+    add_subdirectory(md5)
+    target_link_libraries(external ext_md5)
+endif(BUILD_EXT_MD5)
 
 
 # use lua/js specific libs by property to prevent conflict
@@ -59,10 +116,12 @@ if(BUILD_LUA_LIBS)
 endif()
 
 if(NOT LINUX)
-    add_subdirectory(curl)
+    if(BUILD_EXT_CURL)
+        add_subdirectory(curl)
+        target_link_libraries(external ext_curl)
+    endif(BUILD_EXT_CURL)
     add_subdirectory(png)
     target_link_libraries(external 
-        ext_curl
         ext_png
     )
 endif(NOT LINUX)
@@ -108,15 +167,19 @@ if(WINDOWS OR MACOSX OR LINUX)
 endif()
 
 if(MACOSX OR ANDROID OR WINDOWS)
-    add_subdirectory(zlib)
-    target_link_libraries(external 
-        ext_zlib
-    )
+    if(BUILD_EXT_ZLIB)
+        add_subdirectory(zlib)
+        target_link_libraries(external 
+            ext_zlib
+        )
+    endif(BUILD_EXT_ZLIB)
 endif()
 
 # unzip depend on zlib
-add_subdirectory(unzip)
-target_link_libraries(external ext_unzip)
+if(BUILD_EXT_UNZIP)
+    add_subdirectory(unzip)
+    target_link_libraries(external ext_unzip)
+endif(BUILD_EXT_UNZIP)
 
 # put "external" into External folder, too
 set_target_properties(external


### PR DESCRIPTION
This change allows the game to provide it's own version of most of the 3rd party libraries that are in the /external folder. The primary reason for this is that many of the libraries are not updated to the version required by game developers (with bug fixes/new features etc).

Instead of forcing game developers to maintain a custom version of the Cocos2d-x which has the new libraries, this modification allows the game to disable the libraries built by Cocos2d-x, and the game can then link it's own version into the build.

This code change does not change the default behavior of the current external libs, so everything will work as normal unless the game developer wishes to override one of the 3rd party libraries.

Note: Same as #358 for v3 of Cocos2d-x, except this request doesn't have references to SQLite, since it seems to have been removed from v4.