### PR TITLE
Revert "Fix issue: https://github.com/cocos2d/cocos2d-x/issues/20182"

### DIFF
--- a/unzip/ioapi_mem.cpp
+++ b/unzip/ioapi_mem.cpp
@@ -56,14 +56,7 @@ voidpf ZCALLBACK fopen_mem_func(voidpf opaque, ZIP_UNUSED const char *filename, 
 
     mem->cur_offset = 0;
 
-    /* pitfall: The builtin memfs management's behavior is not same with official minizip 1.2.0 */
-    ourmemory_t* memfs = (ourmemory_t*)malloc(sizeof(ourmemory_t));
-    if (memfs != nullptr) {
-        memcpy(memfs, mem, sizeof(ourmemory_t));
-
-        return memfs;
-    }
-    return nullptr;
+    return mem;
 }
 
 voidpf ZCALLBACK fopendisk_mem_func(ZIP_UNUSED voidpf opaque, ZIP_UNUSED voidpf stream, ZIP_UNUSED uint32_t number_disk, ZIP_UNUSED int mode)
@@ -151,10 +144,6 @@ long ZCALLBACK fseek_mem_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint32_t 
 int ZCALLBACK fclose_mem_func(ZIP_UNUSED voidpf opaque, ZIP_UNUSED voidpf stream)
 {
     /* Even with grow = 1, caller must always free() memory */
-
-    /* pitfall: The builtin memfs management's behavior is not same with official minizip 1.2.0 */
-    ourmemory_t* mem = (ourmemory_t*)stream;
-    free(mem);
     return 0;
 }
 


### PR DESCRIPTION
Reverts cocos2d/cocos2d-x-3rd-party-libs-bin#379
Could be revert, and later the custom API ```unzOpenBuffer``` should be remove.